### PR TITLE
Changed pullapprove to use different libraries teams based on technology

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -38,12 +38,22 @@ groups:
       required: 1
       request: 0
 
-  libraries:
+  libraries-be:
     conditions:
-    - "'Gemfile*' in files or 'package.json' in files"
+    - "'Gemfile*' in files"
     reviewers:
       teams:
-      - leads
+      - libraries-be
+      - team-production
+    reviews:
+      required: 1
+      request: 0
+  libraries-fe:
+    conditions:
+    - "'package.json' in files or 'tsconfig.json' in files"
+    reviewers:
+      teams:
+      - libraries-fe
       - team-production
     reviews:
       required: 1


### PR DESCRIPTION
J'aimerais tester la possibilité de ramener le concept de libraries mais en l'excluant des team leads, comme ça il faudrait que le chapter lead du bon chapter valide les modifications aux fichiers importants.