### PR TITLE
Exclude rubocop files prodteam required

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -15,7 +15,7 @@ groups:
   prodteam:
     conditions:
     - >
-      'config/*.yml' in files.exclude("*/locales/*") or
+      'config/*.yml' in files.exclude("*/locales/*").exclude("*rubocop*") or
       'Jenkinsfile' in files or
       '*Docker*' in files or
       '*docker*' in files


### PR DESCRIPTION
Je suis pas sur a 100% de la syntaxe... Je me suis basé sur cette partie de la documentation.
![image](https://user-images.githubusercontent.com/7858787/106283770-503b6280-6210-11eb-9e7e-c92fe281ff57.png)
https://docs.pullapprove.com/expressions/

Exemple de PR qui peux être problèmatique: https://github.com/petalmd/petalmd.rails/pull/6710/files