### PR TITLE
[Spike ] Replace pullapprove-conditions with overrides

### DIFF
--- a/.pullapprove-devops.yml
+++ b/.pullapprove-devops.yml
@@ -4,7 +4,7 @@ overrides:
 - if: "base.ref != 'master'"
   status: success
   explanation: "Review not required unless merging to master"
-- "'hotfix' not in labels"  # when using the string type, the default status is "success"
+- "'hotfix' in labels"  # when using the string type, the default status is "success"
 - if: "'WIP' in title"
   status: pending
   explanation: "Work in progress"

--- a/.pullapprove-devops.yml
+++ b/.pullapprove-devops.yml
@@ -1,18 +1,18 @@
 version: 3
 
-pullapprove_conditions:
-- condition: "base.ref == 'master'"
-  unmet_status: success
+overrides:
+- if: "base.ref != 'master'"
+  status: success
   explanation: "Review not required unless merging to master"
 - "'hotfix' not in labels"  # when using the string type, the default status is "success"
-- condition: "'WIP' not in title"
-  unmet_status: pending
+- if: "'WIP' in title"
+  status: pending
   explanation: "Work in progress"
-- condition: "not draft"
-  unmet_status: pending
+- if: "draft"
+  status: pending
   explanation: "Waiting to send reviews as PR is in draft"
-- condition: "'DO NOT MERGE' not in title"
-  unmet_status: failure
+- if: "'DO NOT MERGE' in title"
+  status: failure
   explanation: "Do not merge this PR"
   
 groups:


### PR DESCRIPTION
## Why

https://docs.pullapprove.com/config/pullapprove-conditions/

PullApprove Conditions are deprecated

## Tests

I changed the conditions only for devops to check the behaviours.