### PR TITLE
[Spike] Update PullApprove for the dev repos

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,14 +1,14 @@
 version: 3
-pullapprove_conditions:
-- condition: "base.ref == 'master'"
-  unmet_status: success
+overrides:
+- if: "base.ref != 'master'"
+  status: success
   explanation: "Review not required unless merging to master"
-- "'hotfix' not in labels"  # when using the string type, the default status is "success"
-- condition: "'WIP' not in title"
-  unmet_status: pending
+- "'hotfix' in labels"  # when using the string type, the default status is "success"
+- if: "'WIP' in title"
+  tatus: pending
   explanation: "Work in progress"
-- condition: "not draft"
-  unmet_status: pending
+- if: "draft"
+  status: pending
   explanation: "Waiting to send reviews as PR is in draft"
 
 groups:

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,8 +1,8 @@
 version: 3
 overrides:
-- if: "base.ref != 'master'"
+- if: "base.ref != 'master' and base.ref != 'migration'"
   status: success
-  explanation: "Review not required unless merging to master"
+  explanation: "Review not required unless merging to master or migration"
 - "'hotfix' in labels"  # when using the string type, the default status is "success"
 - if: "'WIP' in title"
   tatus: pending

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -3,13 +3,11 @@ overrides:
 - if: "base.ref != 'master' and base.ref != 'migration'"
   status: success
   explanation: "Review not required unless merging to master or migration"
-- "'hotfix' in labels"  # when using the string type, the default status is "success"
-- if: "'WIP' in title"
-  tatus: pending
-  explanation: "Work in progress"
-- if: "draft"
+- if: "'hotfix' in labels"
+  status: success
+- if: "draft or 'WIP' in title"
   status: pending
-  explanation: "Waiting to send reviews as PR is in draft"
+  explanation: "Work in progress"
 
 groups:
   devops:


### PR DESCRIPTION
## Why

Same as https://github.com/petalmd/pullapprove-config/pull/13 but for the dev repos

We also want PullApprove to trigger when there is a PR with `migration` as base.

## Tests

I created a `migration` branch in `devops-docker` and created a PR with it as base.
